### PR TITLE
Switch backend to flit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,26 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >=3.2,<4.0"]
+build-backend = "flit_core.buildapi"
 
 [project]
-name = "scos_tekrsa"
-dynamic = ["version"]
-description = "Plugin for SCOS Sensor which adds support for Tektronix RSA-series spectrum analyzers"
+name = "scos-tekrsa"
+dynamic = ["version", "description"]
 readme = "README.md"
 requires-python = ">=3.8"
 license = { file = "LICENSE.md" }
 
 authors = [
     { name = "The Institute for Telecommunication Sciences" },
-    { name="Anthony Romaniello", email="aromaniello@ntia.gov"}
+]
+
+maintainers = [
+    { name="Anthony Romaniello", email="aromaniello@ntia.gov"},
 ]
 
 keywords = [
-    "scos", "tektronix", "rsa", "sdr", "spectrum-analyzer", "spectrum",
-    "analyzer", "spectrum analyzer", "usb", "scos-sensor", "scos sensor",
-    "spectrum monitoring", "monitoring", "spectrum management", "docker",
-    "linux", "software defined radio", "radio"
+    "SCOS", "Tektronix", "RSA", "SDR", "spectrum", "analyzer",
+    "sensor", "scos-sensor", "radio", "monitoring", "remote",
+    "distributed", "sensing", "NTIA", "ITS", "telecommunications",
 ]
 
 classifiers = [
@@ -36,18 +37,17 @@ classifiers = [
 ]
 
 dependencies = [
-    "tekrsa-api-wrap>=1.2.2,<2.0",
-    # Impossible to add SCOS Actions while not on PyPi
+    "tekrsa-api-wrap>=1.2.3",
+    "scos_actions @ https://github.com/NTIA/scos-actions/archive/refs/heads/dsp-refactor.zip",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "environs>=9.5.0,<10.0",
-    "hatchling>=1.6.0,<2.0",
-    "pre-commit>=2.20.0,<3.0",
-    "pytest>=7.1.2,<8.0",
-    "pytest-cov>=3.0.0,<4.0",
-    "twine>=4.0.1,<5.0"
+    "environs>=9.5.0",
+    "flit>=3.4,<4",
+    "pre-commit>=2.20.0",
+    "pytest>=7.1.2",
+    "pytest-cov>=3.0.0",
 ]
 
 [project.urls]
@@ -58,13 +58,5 @@ dev = [
 "ITS Website" = "https://its.ntia.gov"
 "Tektronix Website" = "https://www.tek.com/en"
 
-[tool.hatch.version]
-path = "src/scos_tekrsa/__about__.py"
-
-[tool.hatch.build]
-skip-excluded-dirs = true
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/scos_tekrsa"]
-
-[tool.hatch.build.targets.sdist]
+[tool.flit.module]
+name = "scos_tekrsa"

--- a/src/scos_tekrsa/__init__.py
+++ b/src/scos_tekrsa/__init__.py
@@ -1,0 +1,5 @@
+"""Plugin for SCOS Sensor which adds support for Tektronix RSA-series spectrum analyzers
+
+For detailed usage information, refer to the README file.
+"""
+__version__ = "1.0.0"


### PR DESCRIPTION
Switch from Hatchling to flit for the packaging backend. This allows direct reference (i.e. from GitHub) dependencies.