### PR TITLE
Base Image: Ubuntu 18.04 -> 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ file:
 1. In the newly-created `env` file, set the `BASE_IMAGE`:
 
     ```text
-    BASE_IMAGE=ghcr.io/ntia/scos-tekrsa/tekrsa_usb:0.1.6
+    BASE_IMAGE=ghcr.io/ntia/scos-tekrsa/tekrsa_usb:0.2.0
     ```
 
 1. Get environment variables:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ file:
 1. In the newly-created `env` file, set the `BASE_IMAGE`:
 
     ```text
-    BASE_IMAGE=ghcr.io/ntia/scos-tekrsa/tekrsa_usb:0.1.5
+    BASE_IMAGE=ghcr.io/ntia/scos-tekrsa/tekrsa_usb:0.1.6
     ```
 
 1. Get environment variables:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Create Tektronix.rules as described in RSA API installation notes
 RUN mkdir -p /etc/udev/rules.d/
 RUN touch /etc/udev/rules.d/Tektronix.rules
 RUN echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0699\", MODE=\"0666\", GROUP=\"plugdev\", ATTR{power/autosuspend =\"-1\", ATTR{power/control}=\"on\", ATTR{bMaxPower}=\"500mA\"" >> /etc/udev/rules.d/Tektronix.rules
 RUN chmod a+r /etc/udev/rules.d/Tektronix.rules
-
-# Locale fixes
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,3 +5,7 @@ RUN mkdir -p /etc/udev/rules.d/
 RUN touch /etc/udev/rules.d/Tektronix.rules
 RUN echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0699\", MODE=\"0666\", GROUP=\"plugdev\", ATTR{power/autosuspend =\"-1\", ATTR{power/control}=\"on\", ATTR{bMaxPower}=\"500mA\"" >> /etc/udev/rules.d/Tektronix.rules
 RUN chmod a+r /etc/udev/rules.d/Tektronix.rules
+
+# Locale fixes
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8


### PR DESCRIPTION
- Upgrades the `tekrsa_usb` base image from Ubuntu 18.04 to Ubuntu 20.04, released as [`tekrsa_usb:0.2.0`](https://github.com/NTIA/scos-tekrsa/pkgs/container/scos-tekrsa%2Ftekrsa_usb/34978627?tag=0.2.0)
- Updates documentation to reflect the update

No changes to the `scos_tekrsa` package are included. This PR only affects the Docker image supplied in the repository and required for using `scos_tekrsa`.