### PR TITLE
Add classification to YAML configs

### DIFF
--- a/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_ATT_DL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_ATT_DL.yml
@@ -5,3 +5,4 @@ single_frequency_time_domain_iq:
   sample_rate: 56e6
   duration_ms: 714
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_ATT_UL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_ATT_UL.yml
@@ -5,3 +5,4 @@ single_frequency_time_domain_iq:
   sample_rate: 56e6
   duration_ms: 714
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_T-Mobile_DL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_T-Mobile_DL.yml
@@ -5,3 +5,4 @@ single_frequency_time_domain_iq:
   sample_rate: 56e6
   duration_ms: 714
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_T-Mobile_UL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_T-Mobile_UL.yml
@@ -5,3 +5,4 @@ single_frequency_time_domain_iq:
   sample_rate: 56e6
   duration_ms: 714
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_Verizon_DL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_Verizon_DL.yml
@@ -5,3 +5,4 @@ single_frequency_time_domain_iq:
   sample_rate: 56e6
   duration_ms: 714
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_Verizon_UL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_iq_700MHz_Verizon_UL.yml
@@ -5,3 +5,4 @@ single_frequency_time_domain_iq:
   sample_rate: 56e6
   duration_ms: 714
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_ATT_DL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_ATT_DL.yml
@@ -6,3 +6,4 @@ single_frequency_fft:
   fft_size: 2048
   nffts: 300
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_ATT_UL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_ATT_UL.yml
@@ -6,3 +6,4 @@ single_frequency_fft:
   fft_size: 2048
   nffts: 300
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_T-Mobile_DL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_T-Mobile_DL.yml
@@ -6,3 +6,4 @@ single_frequency_fft:
   fft_size: 2048
   nffts: 300
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_T-Mobile_UL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_T-Mobile_UL.yml
@@ -6,3 +6,4 @@ single_frequency_fft:
   fft_size: 2048
   nffts: 300
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_Verizon_DL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_Verizon_DL.yml
@@ -6,3 +6,4 @@ single_frequency_fft:
   fft_size: 2048
   nffts: 300
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_Verizon_UL.yml
+++ b/src/scos_tekrsa/configs/actions-300/acquire_m4s_700MHz_Verizon_UL.yml
@@ -6,3 +6,4 @@ single_frequency_fft:
   fft_size: 2048
   nffts: 300
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3555_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3555_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3555_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3555_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3565_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3565_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3565_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3565_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3575_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3575_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3575_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3575_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3585_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3585_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3585_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3585_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3595_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3595_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3595_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3595_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3605_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3605_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3605_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3605_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3615_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3615_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3615_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3615_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3625_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3625_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3625_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3625_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3635_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3635_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3635_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3635_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3645_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3645_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3645_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3645_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3655_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3655_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3655_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3655_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3665_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3665_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3665_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3665_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3675_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3675_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3675_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3675_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3685_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3685_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3685_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3685_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3695_IQ.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3695_IQ.yml
@@ -8,3 +8,4 @@ single_frequency_time_domain_iq:
   sample_rate: 14e6
   duration_ms: 4000
   nskip: 0
+  classification: UNCLASSIFIED

--- a/src/scos_tekrsa/configs/actions-500-600/3695_M4.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/3695_M4.yml
@@ -9,3 +9,4 @@ single_frequency_fft:
   fft_size: 1400
   nffts: 4000
   nskip: 0
+  classification: UNCLASSIFIED


### PR DESCRIPTION
Add `classification` to all included YAML action configs. All are set to `"UNCLASSIFIED"`.

This is required by SCOS Actions after NTIA/scos-actions#43, and the change has no impact for other versions.

Merging into `power-cycle` to so that this change gets brought into `main` alongside the others in #26 