### PR TITLE
Update IQ capture method to stream direct to memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 
 dependencies = [
     "environs>=9.5.0",
-    "tekrsa-api-wrap>=1.2.3",
+    "tekrsa-api-wrap>=1.2.4",
     "scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 
 dependencies = [
     "environs>=9.5.0",
-    "tekrsa-api-wrap>=1.2.4",
+    "tekrsa-api-wrap>=1.3.0",
     "scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.1",
 ]
 

--- a/src/scos_tekrsa/hardware/tekrsa_sigan.py
+++ b/src/scos_tekrsa/hardware/tekrsa_sigan.py
@@ -312,7 +312,7 @@ class TekRSASigan(SignalAnalyzerInterface):
 
         while True:
             self._capture_time = utils.get_datetime_str_now()
-            data, status = self.rsa.IQSTREAM_Tempfile_NoConfig(durationMsec, True)
+            data, status = self.rsa.IQSTREAM_Acquire(durationMsec, True)
 
             data = data[nskip:]  # Remove extra samples, if any
             data_len = len(data)


### PR DESCRIPTION
Updates `acquire_time_domain_samples` to use the new IQ streaming function added in NTIA/tekrsa-api-wrap#13.

This results in increased performance with drastically reduced overhead time when recording IQ samples. It also completely removes the disk usage by the old `IQSTREAM_Tempfile` method, since IQ samples are streamed directly to memory.

This PR is ready, but a draft until other changes are merged.