### PR TITLE
Update SEA action configs (dynamic range, out-of-band)

### DIFF
--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_03dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_03dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -22
   attenuation: 3
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_05dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_05dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -20
   attenuation: 5
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_10dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_10dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -15
   attenuation: 10
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_15dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_15dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -10
   attenuation: 15
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_20dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_20dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -5
   attenuation: 20
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_25dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_Calibrate_25dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: 0
   attenuation: 25
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_03dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_03dB_Attenuation.yml
@@ -21,7 +21,7 @@ nasctn_sea_data_product:
   # round_to_places: 2
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -22
   attenuation: 3
   sample_rate: 14e6
 # Acquisition settings (3550-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_05dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_05dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -20
   attenuation: 5
   sample_rate: 14e6
 # Acquisition settings (3550-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_10dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_10dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -15
   attenuation: 10
   sample_rate: 14e6
 # Acquisition settings (3550-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_15dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_15dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -10
   attenuation: 15
   sample_rate: 14e6
 # Acquisition settings (3550-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_20dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_20dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -5
   attenuation: 20
   sample_rate: 14e6
 # Acquisition settings (3550-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_25dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_DataProduct_25dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: 0
   attenuation: 25
   sample_rate: 14e6
 # Acquisition settings (3550-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_00dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_00dB_Attenuation.yml
@@ -29,6 +29,7 @@ y_factor_cal:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6
   # IIR Filter Settings:
   # Optionally apply a low-pass IIR filter before Y-Factor
   iir_apply: True

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_03dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_03dB_Attenuation.yml
@@ -29,6 +29,7 @@ y_factor_cal:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6
   # IIR Filter Settings:
   # Optionally apply a low-pass IIR filter before Y-Factor
   iir_apply: True

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_03dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_03dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -22
   attenuation: 3
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_05dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_05dB_Attenuation.yml
@@ -29,6 +29,7 @@ y_factor_cal:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6
   # IIR Filter Settings:
   # Optionally apply a low-pass IIR filter before Y-Factor
   iir_apply: True

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_05dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_05dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -20
   attenuation: 5
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_10dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_10dB_Attenuation.yml
@@ -29,6 +29,7 @@ y_factor_cal:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6
   # IIR Filter Settings:
   # Optionally apply a low-pass IIR filter before Y-Factor
   iir_apply: True

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_10dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_10dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -15
   attenuation: 10
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_15dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_15dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -10
   attenuation: 15
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_15dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_15dB_Attenuation.yml
@@ -29,6 +29,7 @@ y_factor_cal:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6
   # IIR Filter Settings:
   # Optionally apply a low-pass IIR filter before Y-Factor
   iir_apply: True

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_20dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_20dB_Attenuation.yml
@@ -29,6 +29,7 @@ y_factor_cal:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6
   # IIR Filter Settings:
   # Optionally apply a low-pass IIR filter before Y-Factor
   iir_apply: True

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_20dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_Calibrate_20dB_Attenuation.yml
@@ -7,7 +7,7 @@ y_factor_cal:
   noise_diode_off: noise_diode_off
   # Signal Analyzer Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -5
   attenuation: 20
   sample_rate: 14e6
   duration_ms: 1000

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_00dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_00dB_Attenuation.yml
@@ -39,3 +39,4 @@ nasctn_sea_data_product:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_03dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_03dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -22
   attenuation: 3
   sample_rate: 14e6
 # Acquisition settings (3540-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_03dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_03dB_Attenuation.yml
@@ -39,3 +39,4 @@ nasctn_sea_data_product:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_05dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_05dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -20
   attenuation: 5
   sample_rate: 14e6
 # Acquisition settings (3540-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_05dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_05dB_Attenuation.yml
@@ -39,3 +39,4 @@ nasctn_sea_data_product:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_10dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_10dB_Attenuation.yml
@@ -39,3 +39,4 @@ nasctn_sea_data_product:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_10dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_10dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -15
   attenuation: 10
   sample_rate: 14e6
 # Acquisition settings (3540-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_15dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_15dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -10
   attenuation: 15
   sample_rate: 14e6
 # Acquisition settings (3540-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_15dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_15dB_Attenuation.yml
@@ -39,3 +39,4 @@ nasctn_sea_data_product:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_20dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_20dB_Attenuation.yml
@@ -16,7 +16,7 @@ nasctn_sea_data_product:
   td_bin_size_ms: 10
 # Sigan Settings
   preamp_enable: True
-  reference_level: -25
+  reference_level: -5
   attenuation: 20
   sample_rate: 14e6
 # Acquisition settings (3540-3700 MHz in 10 MHz steps, each 4s long)

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_20dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_EXT_DataProduct_20dB_Attenuation.yml
@@ -39,3 +39,4 @@ nasctn_sea_data_product:
     - 3675e6
     - 3685e6
     - 3695e6
+    - 3705e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_03dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_03dB_Attenuation.yml
@@ -2,7 +2,7 @@ stepped_frequency_time_domain_iq:
   # 500 ms captures every 10 MHz
   name: CBRS_IQ_03dB_Attenuation
   rf_path: antenna
-  reference_level: -25
+  reference_level: -22
   attenuation: 3
   preamp_enable: True
   sample_rate: 14e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_05dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_05dB_Attenuation.yml
@@ -2,7 +2,7 @@ stepped_frequency_time_domain_iq:
   # 500 ms captures every 10 MHz
   name: CBRS_IQ_05dB_Attenuation
   rf_path: antenna
-  reference_level: -25
+  reference_level: -20
   attenuation: 5
   preamp_enable: True
   sample_rate: 14e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_10dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_10dB_Attenuation.yml
@@ -2,7 +2,7 @@ stepped_frequency_time_domain_iq:
   # 500 ms captures every 10 MHz
   name: CBRS_IQ_10dB_Attenuation
   rf_path: antenna
-  reference_level: -25
+  reference_level: -15
   attenuation: 10
   preamp_enable: True
   sample_rate: 14e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_15dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_15dB_Attenuation.yml
@@ -2,7 +2,7 @@ stepped_frequency_time_domain_iq:
   # 500 ms captures every 10 MHz
   name: CBRS_IQ_15dB_Attenuation
   rf_path: antenna
-  reference_level: -25
+  reference_level: -20
   attenuation: 15
   preamp_enable: True
   sample_rate: 14e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_20dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_20dB_Attenuation.yml
@@ -2,7 +2,7 @@ stepped_frequency_time_domain_iq:
   # 500 ms captures every 10 MHz
   name: CBRS_IQ_20dB_Attenuation
   rf_path: antenna
-  reference_level: -25
+  reference_level: -5
   attenuation: 20
   preamp_enable: True
   sample_rate: 14e6

--- a/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_25dB_Attenuation.yml
+++ b/src/scos_tekrsa/configs/actions-500-600/CBRS_IQ_25dB_Attenuation.yml
@@ -2,7 +2,7 @@ stepped_frequency_time_domain_iq:
   # 500 ms captures every 10 MHz
   name: CBRS_IQ_25dB_Attenuation
   rf_path: antenna
-  reference_level: -25
+  reference_level: 0
   attenuation: 25
   preamp_enable: True
   sample_rate: 14e6


### PR DESCRIPTION
- Updates the reference level setting in action configs which use sigan attenuation, in order to maximize dynamic range while attenuating high power signals. From lab characterization, reference level should be increased by the same amount of attenuation that is added. Previously, reference level was kept constant while attenuation was stepped in.
- Update "CBRS_EXT" action configs to measure 3540-3710MHz (previously 3540-3700 MHz)