### PR TITLE
Update scos-actions version, Ubuntu version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ TEKTRONIX and TEK are registered trademarks of Tektronix, Inc.
 
 ## Contact
 
-For technical questions about `scos_tekrsa`, contact Anthony Romaniello, <aromaniello@ntia.gov>
+For technical questions about `scos_tekrsa`, contact the
+[ITS Spectrum Monitoring Team](mailto:spectrummonitoring@ntia.gov).
 
 ## Disclaimer
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,5 +7,5 @@ RUN echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0699\", MODE=\"0666\", GROUP=\"p
 RUN chmod a+r /etc/udev/rules.d/Tektronix.rules
 
 # Locale fixes
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Create Tektronix.rules as described in RSA API installation notes
 RUN mkdir -p /etc/udev/rules.d/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 dependencies = [
     "environs>=9.5.0",
     "tekrsa-api-wrap>=1.3.3",
-    "scos_actions @ git+https://github.com/NTIA/scos-actions@SEA-234_ubuntu22.04_python3.10_ray2.10",
+    "scos_actions @ git+https://github.com/NTIA/scos-actions@master",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 dependencies = [
     "environs>=9.5.0",
     "tekrsa-api-wrap>=1.3.3",
-    "scos_actions @ git+https://github.com/NTIA/scos-actions@10.0.2",
+    "scos_actions @ git+https://github.com/NTIA/scos-actions@SEA-234_ubuntu22.04_python3.10",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 dependencies = [
     "environs>=9.5.0",
     "tekrsa-api-wrap>=1.3.3",
-    "scos_actions @ git+https://github.com/NTIA/scos-actions@SEA-234_ubuntu22.04_python3.10",
+    "scos_actions @ git+https://github.com/NTIA/scos-actions@SEA-234_ubuntu22.04_python3.10_ray2.10",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Ubuntu version updated to 22.04
- Use new version of scos-actions with updates for new Ubuntu version, new Django Version, new Ray version
- Update contact information